### PR TITLE
Update footer.html to include COPYRIGHT_START_YEAR

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -2,6 +2,6 @@
   <hr class="small">
   <center>
   <p>Built with <a href="http://getpelican.com">Pelican</a> and the <a href="https://github.com/gjreda/newbird-pelican-theme">newbird</a> theme</p>
-  <p>&copy; Copyright {{ AUTHOR }}, 2013 to present</p>
+  <p>&copy; Copyright {{ AUTHOR }}, {{ COPYRIGHT_START_YEAR }} to present</p>
   </center>
 </footer>


### PR DESCRIPTION
The footer did not use the variable COPYRIGHT_START_YEAR that is declared in the pelicanconf.py.